### PR TITLE
Fix creating the user if it doesn't exist

### DIFF
--- a/imap_auth_provider.py
+++ b/imap_auth_provider.py
@@ -63,7 +63,7 @@ class IMAPAuthProvider:
 
         # Create the user in Matrix if it doesn't exist yet
         if not (yield self.account_handler.check_user_exists(user_id)):
-            yield self.account_handler.register_user(localpart=localpart, mail=[email])
+            yield self.account_handler.register_user(localpart=localpart, emails=[email])
 
         defer.returnValue(True)
 


### PR DESCRIPTION
This fixes the following:
```
Traceback (most recent call last):
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/synapse/http/server.py", line 78, in wrapped_request_handler
    await h(self, request)
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/synapse/http/server.py", line 331, in _async_render
    callback_return = await callback_return
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/synapse/rest/client/v1/login.py", line 150, in on_POST
    result = await self._do_other_login(login_submission)
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/synapse/rest/client/v1/login.py", line 281, in _do_other_login
    identifier["user"], login_submission
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/synapse/handlers/auth.py", line 622, in validate_login
    is_valid = yield provider.check_password(qualified_user_id, password)
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/opt/venvs/matrix-synapse/lib/python3.6/site-packages/imap_auth_provider.py", line 66, in check_password
    yield self.account_handler.register_user(localpart=localpart, mail=[email])
TypeError: register_user() got an unexpected keyword argument 'mail'
```